### PR TITLE
Update NikonDataLoader.py

### DIFF
--- a/Python/tigre/utilities/io/NikonDataLoader.py
+++ b/Python/tigre/utilities/io/NikonDataLoader.py
@@ -60,7 +60,7 @@ def readXtekctGeometry(filepath):
 
     ## Detector information
     # Number of pixel in the detector
-    geometry.nDetector = numpy.array((float(cfg["DetectorPixelsX"]), float(cfg["DetectorPixelsY"])))
+    geometry.nDetector = numpy.array((int(cfg["DetectorPixelsX"]), int(cfg["DetectorPixelsY"])))
     # Size of pixels in the detector
     geometry.dDetector = numpy.array(
         (float(cfg["DetectorPixelSizeX"]), float(cfg["DetectorPixelSizeY"]))
@@ -75,8 +75,9 @@ def readXtekctGeometry(filepath):
 
     ## Image information
     # Number of voxels for the volume
+    # the algos require these to be integers.
     geometry.nVoxel = numpy.array(
-        (float(cfg["VoxelsX"]), float(cfg["VoxelsY"]), float(cfg["VoxelsZ"]))
+        (int(cfg["VoxelsX"]), int(cfg["VoxelsY"]), int(cfg["VoxelsZ"]))
     )
     # Size of each voxel
     geometry.dVoxel = numpy.array(
@@ -157,9 +158,11 @@ def loadNikonProjections(folder, geometry, angles, **kwargs):
     image = numpy.asarray(image).astype(numpy.float32)
     projections = numpy.zeros([len(indices), image.shape[0], image.shape[1]], dtype=numpy.single)
     projections[0, :, :] = -numpy.log(image / float(geometry.whitelevel))
-    index = 1
+    #Python uses zero-based indexing
+    # if we start with index = 1 we get an error
+    # use enumerate, it's cleaner
     print("Loading Nikon dataset: " + folder)
-    for i in tqdm(indices):
+    for index, i in enumerate(tqdm(indices)):
         image = Image.open(os.path.join(folder, files[i]))
         image = numpy.asarray(image).astype(numpy.float32)
         projections[index, :, :] = -numpy.log(image / float(geometry.whitelevel))


### PR DESCRIPTION
Fixed the loop on images, previously started at index =1, this led to errors when loading partial datasets as the last entry is out of the array's shape

Also, the recon algos all require the geometry object to have the number of voxels and number of detector pixels stored as integers, not as floats. previous version would not run.